### PR TITLE
Prevent double server initialization

### DIFF
--- a/src/PoolServer.js
+++ b/src/PoolServer.js
@@ -74,6 +74,9 @@ class PoolServer extends Nimiq.Observable {
         /** @type {number} */
         this._averageHashrate = 0;
 
+        /** @type {boolean} */
+        this._started = false;
+
         setInterval(() => this._checkUnbanIps(), PoolServer.UNBAN_IPS_INTERVAL);
 
         setInterval(() => this._calculateHashrate(), PoolServer.HASHRATE_INTERVAL);
@@ -82,6 +85,9 @@ class PoolServer extends Nimiq.Observable {
     }
 
     async start() {
+        if (this._started) return;
+        this._started = true;
+
         this._currentLightHead = this.consensus.blockchain.head.toLight();
         await this._updateTransactions();
 


### PR DESCRIPTION
I had the issue, that my node process (lost and) re-established consensus in the middle of it running. This is valid behaviour of the nimiq node. It then fires the `established` event again on the consensus.

The `PoolServer` then tried to start up again, creating a `Error address in use`, but also messing up the existing server, such that it detected ALL clients as sending shares with invalid extradata and banning all of them!

To prevent this, this PR prevents double-starting the `PoolServer`.