### PR TITLE
Fix pool server launch omission

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,8 @@ for (const seedPeer of config.seedPeers) {
 
     if (config.poolServer.enabled) {
         const poolServer = new PoolServer($.consensus, config.pool, config.poolServer.port, config.poolServer.mySqlPsw, config.poolServer.mySqlHost, config.poolServer.sslKeyPath, config.poolServer.sslCertPath);
-
+	poolServer.start();
+	
         if (config.poolMetricsServer.enabled) {
             $.metricsServer = new MetricsServer(config.poolServer.sslKeyPath, config.poolServer.sslCertPath, config.poolMetricsServer.port, config.poolMetricsServer.password);
             $.metricsServer.init(poolServer);


### PR DESCRIPTION
## What does this PR do ?

This PR adds the pool server launch when it is specified in the config file.  
A call to `poolServer.start()` was missing here [index.js#L81](https://github.com/nimiq-network/mining-pool/blob/master/index.js#L81)

### How should this be manually tested?

  - Step 1 : Run `node index.js --config server.sample.conf`
  - Step 2 : Check the presence of `[I 18:54:20] PoolServer: Started server on port 8444
` in the logs
