### PR TITLE
Add Device Label

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -55,6 +55,11 @@ CREATE TABLE pool.payout_request (
   user         INTEGER    NOT NULL UNIQUE REFERENCES pool.user(id)
 );
 
+CREATE TABLE pool.device (
+  id           INTEGER     PRIMARY KEY UNSIGNED NOT NULL,
+  label        VARCHAR(64) DEFAULT NULL
+);
+
 GRANT SELECT,INSERT ON pool.user TO 'pool_server'@'localhost';
 GRANT SELECT ON pool.user TO 'pool_service'@'localhost';
 GRANT SELECT ON pool.user TO 'pool_payout'@'localhost';
@@ -82,3 +87,6 @@ GRANT SELECT ON pool.payout TO 'pool_info'@'localhost';
 GRANT SELECT,INSERT,DELETE ON pool.payout_request TO 'pool_server'@'localhost';
 GRANT SELECT,DELETE ON pool.payout_request TO 'pool_payout'@'localhost';
 GRANT SELECT ON pool.payout_request TO 'pool_info'@'localhost';
+
+GRANT SELECT,INSERT,UPDATE ON pool.device TO 'pool_server'@'localhost';
+GRANT SELECT ON pool.device TO 'pool_info'@'localhost';

--- a/src/PoolAgent.js
+++ b/src/PoolAgent.js
@@ -135,6 +135,7 @@ class PoolAgent extends Nimiq.Observable {
 
         this._address = Nimiq.Address.fromUserFriendlyAddress(msg.address);
         this._deviceId = msg.deviceId;
+        this._deviceLabel = msg.deviceLabel;
         switch (msg.mode) {
             case PoolAgent.MODE_SMART:
                 this.mode = PoolAgent.Mode.SMART;
@@ -156,6 +157,9 @@ class PoolAgent extends Nimiq.Observable {
         this._lastSpsReset = Date.now();
         this._timers.resetTimeout('recalc-difficulty', () => this._recalcDifficulty(), this._pool.config.spsTimeUnit);
         this._userId = await this._pool.getStoreUserId(this._address);
+        if (this._deviceId) {
+          await this._pool.storeDeviceLabel(this._deviceId, this._deviceLabel);
+        }
         this._regenerateNonce();
         this._regenerateExtraData();
 
@@ -172,7 +176,8 @@ class PoolAgent extends Nimiq.Observable {
         this._timers.resetInterval('send-balance', () => this.sendBalance(), 1000 * 60 * 5);
         this._timers.resetInterval('send-keep-alive-ping', () => this._ws.ping(), 1000 * 10);
 
-        Nimiq.Log.i(PoolAgent, `REGISTER ${this._address.toUserFriendlyAddress()}, current balance: ${await this._pool.getUserBalance(this._userId)}`);
+        Nimiq.Log.i(PoolAgent, `REGISTER ${this._address.toUserFriendlyAddress()} device: `
+          + `${this._deviceId}, current balance: ${await this._pool.getUserBalance(this._userId)}`);
     }
 
     /**

--- a/src/PoolServer.js
+++ b/src/PoolServer.js
@@ -333,6 +333,18 @@ class PoolServer extends Nimiq.Observable {
     }
 
     /**
+     * @param {number} deviceId
+     * @param {string} [deviceLabel]
+     */
+    async storeDeviceLabel(deviceId, deviceLabel) {
+        deviceLabel = deviceLabel
+          ? deviceLabel.slice(0, 64)
+          : null;
+        await this.connectionPool.execute("INSERT INTO device (id, label) VALUES (?, ?) ON DUPLICATE KEY UPDATE label=?",
+          [deviceId, deviceLabel, deviceLabel]);
+    }
+
+    /**
      * @param {PoolAgent} agent
      */
     removeAgent(agent) {


### PR DESCRIPTION
Expect optional `deviceLabel` field in `REGISTER` message, saving it to a new table called `device`, indexed by `id`. This can be used like:

```
CREATE PROCEDURE getUserDevices(IN address VARCHAR(28), IN seconds INT)
BEGIN
  SELECT device.label as label, COUNT(DISTINCT share.device) as deviceCount, SUM(share.difficulty) * 65536 / seconds as hashRate
    FROM share, device, user
    WHERE user.address = address
    AND share.user = user.id
    AND device.id = share.device
    AND share.datetime > (UNIX_TIMESTAMP(now()) - seconds) * 1000
    GROUP BY device.label;
END
```