### PR TITLE
Add separate read connection for server and batch share inserts

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,15 @@ for (const seedPeer of config.seedPeers) {
     }
 
     if (config.poolServer.enabled) {
-        const poolServer = new PoolServer($.consensus, config.pool, config.poolServer.port, config.poolServer.mySqlPsw, config.poolServer.mySqlHost, config.poolServer.sslKeyPath, config.poolServer.sslCertPath);
+        const poolServer = new PoolServer(
+            $.consensus,
+            config.pool,
+            config.poolServer.port,
+            config.poolServer.mySqlPsw,
+            config.poolServer.mySqlHost,
+            config.poolServer.mySqlReadHost || config.poolServer.mySqlHost,
+            config.poolServer.sslKeyPath,
+            config.poolServer.sslCertPath);
 
         if (config.poolMetricsServer.enabled) {
             $.metricsServer = new MetricsServer(config.poolServer.sslKeyPath, config.poolServer.sslCertPath, config.poolMetricsServer.port, config.poolMetricsServer.password);

--- a/server.sample.conf
+++ b/server.sample.conf
@@ -17,9 +17,14 @@
         // Password of the MySQL pool_server user.
         mySqlPsw: 'password',
 
-        // Host the MySQL database runs on.
+        // Host URL the MySQL database runs on.
         // Default: 'localhost'
         mySqlHost: 'localhost'
+
+        // (Optional) A URL for a read-only endpoint of the MySQL server. Useful for
+        // scaling horizontally.
+        // Default: 'localhost'
+        //mySqlReadHost: 'localhost'
     },
 
     // General mining pool configuration

--- a/spec/PoolAgent.spec.js
+++ b/spec/PoolAgent.spec.js
@@ -94,7 +94,7 @@ describe('PoolAgent', () => {
     it('does not count shares onto old blocks (smart mode)', (done) => {
         (async () => {
             const consensus = await Nimiq.Consensus.volatileFull();
-            const poolServer = new PoolServer(consensus, POOL_CONFIG, 9999, '', '', '', '');
+            const poolServer = new PoolServer(consensus, POOL_CONFIG, 9999, '', '', '', '', '');
             await poolServer.start();
 
             let fixFakeTime = 0;
@@ -135,7 +135,7 @@ describe('PoolAgent', () => {
     it('bans clients with too many invalid shares', (done) => {
         (async () => {
             const consensus = await Nimiq.Consensus.volatileFull();
-            const poolServer = new PoolServer(consensus, POOL_CONFIG, 9999, '', '', '', '');
+            const poolServer = new PoolServer(consensus, POOL_CONFIG, 9999, '', '', '', '', '');
             await poolServer.start();
             const time = new Nimiq.Time();
             spyOn(time, 'now').and.callFake(() => 0);
@@ -171,7 +171,7 @@ describe('PoolAgent', () => {
             const clientAddress = keyPair.publicKey.toAddress();
 
             const consensus = await Nimiq.Consensus.volatileFull();
-            const poolServer = new PoolServer(consensus, POOL_CONFIG, 9999, '', 'localhost', '', '');
+            const poolServer = new PoolServer(consensus, POOL_CONFIG, 9999, '', 'localhost', 'localhost', '', '');
             await poolServer.start();
             const poolAgent = new PoolAgent(poolServer, { close: () => {}, send: () => {} }, Nimiq.NetAddress.fromIP('1.2.3.4'));
             spyOn(poolAgent, '_regenerateNonce').and.callFake(() => { poolAgent._nonce = 42 });

--- a/src/Config.js
+++ b/src/Config.js
@@ -69,7 +69,8 @@ const DEFAULT_CONFIG = /** @type {Config} */ {
         sslCertPath: null,
         sslKeyPath: null,
         mySqlPsw: null,
-        mySqlHost: null
+        mySqlHost: null,
+        mySqlReadHost: null
     },
     poolService: {
         enabled: false,
@@ -134,7 +135,8 @@ const CONFIG_TYPES = {
             certPath: 'string',
             keyPath: 'string',
             mySqlPsw: 'string',
-            mySqlHost: 'string'
+            mySqlHost: 'string',
+            mySqlReadHost: 'string'
         }
     },
     poolService: {

--- a/src/PoolServer.js
+++ b/src/PoolServer.js
@@ -7,17 +7,25 @@ const fs = require('fs');
 const PoolAgent = require('./PoolAgent.js');
 const Helper = require('./Helper.js');
 
+/**
+ * @typedef Deferred
+ * @property {Promise} promise
+ * @property {Function} resolve
+ * @property {Function} reject
+ */
+
 class PoolServer extends Nimiq.Observable {
     /**
      * @param {Nimiq.FullConsensus} consensus
      * @param {PoolConfig} config
      * @param {number} port
      * @param {string} mySqlPsw
-     * @param {string} mySqlHost
+     * @param {string} mySqlWriteHost
+     * @param {string} mySqlReadHost
      * @param {string} sslKeyPath
      * @param {string} sslCertPath
      */
-    constructor(consensus, config, port, mySqlPsw, mySqlHost, sslKeyPath, sslCertPath) {
+    constructor(consensus, config, port, mySqlPsw, mySqlWriteHost, mySqlReadHost, sslKeyPath, sslCertPath) {
         super();
 
         /** @type {Nimiq.FullConsensus} */
@@ -39,7 +47,10 @@ class PoolServer extends Nimiq.Observable {
         this._mySqlPsw = mySqlPsw;
 
         /** @type {string} */
-        this._mySqlHost = mySqlHost;
+        this._mySqlReadHost = mySqlReadHost;
+
+        /** @type {string} */
+        this._mySqlWriteHost = mySqlWriteHost;
 
         /** @type {string} */
         this._sslKeyPath = sslKeyPath;
@@ -74,6 +85,18 @@ class PoolServer extends Nimiq.Observable {
         /** @type {number} */
         this._averageHashrate = 0;
 
+        /** @type {Array[]} */
+        this._queuedShares = [];
+
+        /** @type {number} */
+        this._lastShareInsert = 0;
+
+        /** @type {number} */
+        this._lastKnownHeight = 0;
+
+        /** @type {Deferred} */
+        this._sharesDeferred = { };
+
         /** @type {boolean} */
         this._started = false;
 
@@ -91,8 +114,15 @@ class PoolServer extends Nimiq.Observable {
         this._currentLightHead = this.consensus.blockchain.head.toLight();
         await this._updateTransactions();
 
-        this.connectionPool = await mysql.createPool({
-            host: this._mySqlHost,
+        this.readPool = await mysql.createPool({
+            host: this._mySqlReadHost,
+            user: 'pool_server',
+            password: this._mySqlPsw,
+            database: 'pool'
+        });
+
+        this.writePool = await mysql.createPool({
+            host: this._mySqlWriteHost,
             user: 'pool_server',
             password: this._mySqlPsw,
             database: 'pool'
@@ -276,10 +306,45 @@ class PoolServer extends Nimiq.Observable {
      * @param {Nimiq.Hash} shareHash
      */
     async storeShare(userId, deviceId, prevHash, prevHashHeight, difficulty, shareHash) {
-        let prevHashId = await Helper.getStoreBlockId(this.connectionPool, prevHash, prevHashHeight);
-        const query = "INSERT INTO share (user, device, datetime, prev_block, difficulty, hash) VALUES (?, ?, ?, ?, ?, ?)";
-        const queryArgs = [userId, deviceId, Date.now(), prevHashId, difficulty, shareHash.serialize()];
-        await this.connectionPool.execute(query, queryArgs);
+        let prevHashId;
+        if (prevHashHeight > this._lastKnownHeight) {
+            prevHashId = await Helper.getStoreBlockId(this.writePool, prevHash, prevHashHeight);
+            this._lastKnownHeight = prevHashHeight;
+        } else {
+            prevHashId = await Helper.getBlockId(this.readPool, prevHash);
+        }
+
+        this._queuedShares.push([userId, deviceId, Date.now(), prevHashId, difficulty, shareHash.serialize()]);
+
+        if (!this._sharesDeferred.promise) {
+            this._sharesDeferred.promise = new Promise((resolve, reject) => {
+                this._sharesDeferred.resolve = resolve;
+                this._sharesDeferred.reject = reject;
+            });
+        }
+
+        if (this._lastShareInsert < Date.now() - PoolServer.INSERT_INTERVAL) {
+            this._sharesDeferred.promise = null;
+            return this._storeShares().then(this._sharesDeferred.resolve, this._sharesDeferred.reject);
+        }
+
+        clearTimeout(this._shareTimeout);
+        this._shareTimeout = setTimeout(() => {
+            this._storeShares().then(this._sharesDeferred.resolve, this._sharesDeferred.reject);
+        }, PoolServer.INSERT_INTERVAL);
+        
+        return this._sharesDeferred.promise;
+    }
+
+    _storeShares() {
+        this._lastShareInsert = Date.now();
+        clearTimeout(this._shareTimeout);
+
+        const shares = this._queuedShares.splice(0, this._queuedShares.length);
+        const query = `INSERT INTO share (user, device, datetime, prev_block, difficulty, hash)
+                       VALUES ${shares.map(() => '(?,?,?,?,?,?)').join(',')}`;
+        const queryArgs = [].concat.apply([], shares);
+        return this.writePool.execute(query, queryArgs);
     }
 
     /**
@@ -290,7 +355,7 @@ class PoolServer extends Nimiq.Observable {
     async containsShare(user, shareHash) {
         const query = "SELECT * FROM share WHERE user=? AND hash=?";
         const queryArgs = [user, shareHash.serialize()];
-        const [rows, fields] = await this.connectionPool.execute(query, queryArgs);
+        const [rows, fields] = await this.readPool.execute(query, queryArgs);
         return rows.length > 0;
     }
 
@@ -300,7 +365,7 @@ class PoolServer extends Nimiq.Observable {
      * @returns {Promise<number>}
      */
     async getUserBalance(userId, includeVirtual = false) {
-        return await Helper.getUserBalance(this._config, this.connectionPool, userId, this.consensus.blockchain.height, includeVirtual);
+        return await Helper.getUserBalance(this._config, this.readPool, userId, this.consensus.blockchain.height, includeVirtual);
     }
 
     /**
@@ -309,7 +374,7 @@ class PoolServer extends Nimiq.Observable {
     async storePayoutRequest(userId) {
         const query = "INSERT IGNORE INTO payout_request (user) VALUES (?)";
         const queryArgs = [userId];
-        await this.connectionPool.execute(query, queryArgs);
+        await this.writePool.execute(query, queryArgs);
     }
 
     /**
@@ -318,7 +383,7 @@ class PoolServer extends Nimiq.Observable {
      */
     async hasPayoutRequest(userId) {
         const query = `SELECT * FROM payout_request WHERE user=?`;
-        const [rows, fields] = await this.connectionPool.execute(query, [userId]);
+        const [rows, fields] = await this.readPool.execute(query, [userId]);
         return rows.length > 0;
     }
 
@@ -327,8 +392,8 @@ class PoolServer extends Nimiq.Observable {
      * @returns {Promise.<number>}
      */
     async getStoreUserId(addr) {
-        await this.connectionPool.execute("INSERT IGNORE INTO user (address) VALUES (?)", [addr.toBase64()]);
-        const [rows, fields] = await this.connectionPool.execute("SELECT id FROM user WHERE address=?", [addr.toBase64()]);
+        await this.writePool.execute("INSERT IGNORE INTO user (address) VALUES (?)", [addr.toBase64()]);
+        const [rows, fields] = await this.readPool.execute("SELECT id FROM user WHERE address=?", [addr.toBase64()]);
         return rows[0].id;
     }
 
@@ -403,5 +468,6 @@ class PoolServer extends Nimiq.Observable {
 PoolServer.DEFAULT_BAN_TIME = 1000 * 60 * 10; // 10 minutes
 PoolServer.UNBAN_IPS_INTERVAL = 1000 * 60; // 1 minute
 PoolServer.HASHRATE_INTERVAL = 1000 * 60; // 1 minute
+PoolServer.INSERT_INTERVAL = 1000; // 1 second
 
 module.exports = exports = PoolServer;


### PR DESCRIPTION
@mar-v-in @sisou @fiaxh @styppo 

This PR:
1) Adds a config setting to `PoolServer` for a read-only endpoint. This is extremely important for database scalability, because while read endpoints can be duplicated, write endpoints cannot. The current implementation forces using the same endpoint for reading and writing, meaning the pool owner must use the write endpoint for both reading and writing, and therefore must scale vertically (renting larger servers) rather than horizontally (renting more servers).
2) Batches share insert statements, reducing the amount of queries sent to the write server for better scalability.
3) Buffers the last known block ID, saving many unnecessary read requests.

This ran in production today against over 22,000 connected devices pummeling the servers. Here's the CPU graph of my write DB endpoint before applying my update (left) and after (right):

![](https://i.gyazo.com/d7d90a38a997e9d0e0b46a9a19d740c2.png)

Notice that before the change:
- CPU averaged around 16% at normal load (~400 devices)
- CPU spiked to 45% for 6,000 devices
- CPU spiked to 25% for 3,500 devices

And after the change:
- CPU averages around 8% at normal load (~400 devices)
- CPU spiked to 24% for 22,000 (!) devices

Additionally, here's a snapshot of the databases under the load of 22,000 devices. Note the number of queries/sec for the write endpoint (top) vs the read endpoint (bottom):

![](https://i.gyazo.com/8bb387ce92324215150e9d421ba7afcf.png)

I don't have a screenshot, but prior to this patch these numbers were almost reversed: 95% of the queries ran against the write endpoint (the other 5% being my API endpoint which uses `pool_info` and only calculates stats for the website).

This is an extremely important distinction, again, because if the read endpoints get overloaded they can replicate and split their work, where the write endpoint cannot.